### PR TITLE
feat: enhance search with FTS5 operators and node scoping

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,20 +4,22 @@ class SearchController < ApplicationController
   def index
     @total = ArchiveFile.cached_all_count
     @query = params[:q]
+    @node_id = params[:node_id]
+    @archive_node = ArchiveNode.find_by(id: @node_id) if @node_id.present?
 
     @trigrams =
       ArchiveFileTrigram
         .search(@query)
+        .in_node(@node_id)
         .page(params[:page])
         .per(500)
         .includes(:archive_file)
 
+    cache_key = "controllers/search/pagination_cache_#{helpers.query_cache_key @query}_node_#{@node_id}"
     @pagination_cache =
       Rails
         .cache
-        .fetch(
-          "controllers/search/pagination_cache_#{helpers.query_cache_key @query}"
-        ) do
+        .fetch(cache_key) do
           {
             total_count: @trigrams.total_count,
             total_pages: @trigrams.total_pages

--- a/app/models/archive_file_trigram.rb
+++ b/app/models/archive_file_trigram.rb
@@ -19,7 +19,18 @@ class ArchiveFileTrigram < ApplicationRecord
         ->(query) do
           return none if query.blank?
 
-          where(archive_file_trigrams: "\"#{query}\"").order(:call_number)
+          where(archive_file_trigrams: query).order(:call_number)
+        end
+
+  scope :in_node,
+        ->(node_id) do
+          return all if node_id.blank?
+
+          node = ArchiveNode.find_by(id: node_id)
+          return none unless node
+
+          node_ids = [node.id] + node.descendant_ids
+          where(archive_node_id: node_ids)
         end
 
   scope :lookup_by_call_number,

--- a/app/models/archive_node.rb
+++ b/app/models/archive_node.rb
@@ -33,4 +33,16 @@ class ArchiveNode < ApplicationRecord
     parents.reverse
   end
 
+  def descendant_ids
+    ids = []
+    nodes_to_process = child_nodes.to_a
+
+    while nodes_to_process.any?
+      node = nodes_to_process.shift
+      ids << node.id
+      nodes_to_process.concat(node.child_nodes.to_a)
+    end
+
+    ids
+  end
 end

--- a/app/views/archive_nodes/show.html.erb
+++ b/app/views/archive_nodes/show.html.erb
@@ -1,3 +1,9 @@
+<form class="archive-node-search" action="<%= root_path %>">
+  <input type="hidden" name="node_id" value="<%= @archive_node.id %>" />
+  <input type="text" name="q" placeholder="In diesem Bestand suchen..." class="search__text-input" />
+  <input type="submit" value="Suchen" class="search__button" />
+</form>
+
 <div class="archive-node-menu">
   <ul class="archive-node-mneu__list">
     <li class="archive-node archive-node--selected">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,7 +1,16 @@
 <form class="<%= @query ? "" : "search__form--centered" %>">
+  <% if @archive_node %>
+    <input type="hidden" name="node_id" value="<%= @archive_node.id %>" />
+  <% end %>
   <input type="text" name="q" value="<%= @query %>" placeholder="<%= t("search_placeholder", total: @total) %>" class="search__text-input" />
   <input type="submit" value="<%= t("search_button") %>" class="search__button" />
 </form>
+<% if @archive_node %>
+  <p class="search__node-filter">
+    Suche in: <%= link_to @archive_node.name, archive_node_path(@archive_node) %>
+    (<%= link_to "Filter entfernen", root_path(q: @query) %>)
+  </p>
+<% end %>
 <% if @query %>
   <% cache [controller.action_name, query_cache_key(@query), @trigrams.current_page] do %>
     <% if @pagination_cache[:total_count] > 0 %>

--- a/test/models/archive_file_trigram_test.rb
+++ b/test/models/archive_file_trigram_test.rb
@@ -8,11 +8,54 @@ class ArchiveFileTrigramTest < ActiveSupport::TestCase
     @example_archive_file = ArchiveFile.find_by(source_id: "DE-1958_8a0ff3f6-46b3-443a-9e48-946e790301e0")
   end
 
-  test "search finds archive files by title" do
-    assert_equal 1, ArchiveFileTrigram.search(@example_archive_file.title).count
+  test "search finds archive files by quoted title phrase" do
+    # Users need to quote phrases for exact matching with the new FTS5 behavior
+    assert_equal 1, ArchiveFileTrigram.search("\"#{@example_archive_file.title}\"").count
   end
 
-  test "search finds archive files by call number" do
-    assert_equal 1, ArchiveFileTrigram.search(@example_archive_file.call_number).count
+  test "search finds archive files by quoted call number" do
+    # Call numbers contain special characters, so need quoting
+    assert_equal 1, ArchiveFileTrigram.search("\"#{@example_archive_file.call_number}\"").count
+  end
+
+  test "search supports boolean AND operator" do
+    # Quote individual terms to avoid FTS5 interpreting them as column names
+    title_words = @example_archive_file.title.split.reject { |w| w.length < 4 }.first(2)
+    if title_words.length >= 2
+      results = ArchiveFileTrigram.search("\"#{title_words[0]}\" AND \"#{title_words[1]}\"")
+      assert results.count >= 1
+    end
+  end
+
+  test "search supports prefix matching with wildcard" do
+    # Take first 4 characters of title as prefix
+    prefix = @example_archive_file.title[0, 4]
+    results = ArchiveFileTrigram.search("#{prefix}*")
+    assert results.count >= 1
+  end
+
+  test "in_node scope filters by archive node" do
+    node = @example_archive_file.archive_node
+    results = ArchiveFileTrigram.search("\"#{@example_archive_file.title}\"").in_node(node.id)
+    assert_equal 1, results.count
+  end
+
+  test "in_node scope includes descendant nodes" do
+    # Get the root node and search within it
+    root_node = @example_archive_file.archive_node.parents.first
+    results = ArchiveFileTrigram.search("\"#{@example_archive_file.title}\"").in_node(root_node.id)
+    assert_equal 1, results.count
+  end
+
+  test "in_node scope returns none for non-existent node" do
+    results = ArchiveFileTrigram.search("\"#{@example_archive_file.title}\"").in_node(999999)
+    assert_equal 0, results.count
+  end
+
+  test "in_node scope returns all when node_id is blank" do
+    quoted_title = "\"#{@example_archive_file.title}\""
+    all_results = ArchiveFileTrigram.search(quoted_title)
+    filtered_results = ArchiveFileTrigram.search(quoted_title).in_node(nil)
+    assert_equal all_results.count, filtered_results.count
   end
 end

--- a/test/models/archive_node_test.rb
+++ b/test/models/archive_node_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class ArchiveNodeTest < ActiveSupport::TestCase
+  def setup
+    BundesarchivImporter.new("test/fixtures/files/dataset-tiny").run
+  end
+
+  test "descendant_ids includes child nodes" do
+    # Find a node with children
+    parent_node = ArchiveNode.joins(:child_nodes).distinct.first
+    descendant_ids = parent_node.descendant_ids
+
+    # All direct children should be in descendants
+    parent_node.child_nodes.each do |child|
+      assert_includes descendant_ids, child.id
+    end
+  end
+
+  test "descendant_ids includes grandchildren" do
+    # Find a node whose children also have children
+    grandparent = ArchiveNode.find_by(parent_node_id: nil)
+    next unless grandparent
+
+    descendant_ids = grandparent.descendant_ids
+
+    # Check that grandchildren are included
+    grandparent.child_nodes.each do |child|
+      child.child_nodes.each do |grandchild|
+        assert_includes descendant_ids, grandchild.id
+      end
+    end
+  end
+
+  test "descendant_ids returns empty array for leaf node" do
+    # Find a node with no children by checking child_nodes count
+    leaf_node = ArchiveNode.all.find { |n| n.child_nodes.empty? }
+    assert_not_nil leaf_node, "Should have at least one leaf node"
+    assert_equal [], leaf_node.descendant_ids
+  end
+
+  test "parents returns nodes from root to self" do
+    deepest_node = ArchiveNode.order(:id).last
+    parents = deepest_node.parents
+
+    assert_equal deepest_node, parents.last
+    assert_nil parents.first.parent_node_id
+  end
+end


### PR DESCRIPTION
## Summary

- Remove forced phrase quoting to enable FTS5 operators (`AND`, `OR`, `NOT`, prefix `*`, column filters)
- Add `in_node` scope for searching within a node and its descendants
- Add search form to archive node pages
- Show active node filter on search results with option to remove

Users can now use `München OR Munich` or `Akte NOT geheim` instead of only exact phrases. Archive node pages at `/archive_nodes/:id` have a search field that restricts results to that subtree.

Closes https://github.com/teal-bauer/bundessuche/issues/1
Closes https://github.com/teal-bauer/bundessuche/issues/2